### PR TITLE
Improve room membership handling and password reuse

### DIFF
--- a/server_v4.py
+++ b/server_v4.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""Servidor de chat compatible con client_v4.py (protocolo de texto)."""
+
+import socket
+import threading
+import shlex
+
+HOST = '0.0.0.0'
+PORT = 55555
+
+clients = {}  # username -> socket
+clients_lock = threading.Lock()
+
+rooms = {'global': {'members': set(), 'password': None}}
+rooms_lock = threading.Lock()
+user_active_room = {}     # username -> sala activa
+user_joined_rooms = {}    # username -> set de salas en las que está unido
+
+
+class DisconnectRequested(Exception):
+    """Se lanza cuando el cliente solicita desconexión voluntaria."""
+
+
+def send_line(conn, text):
+    try:
+        conn.sendall((text + "\n").encode('utf-8'))
+    except Exception:
+        raise
+
+
+def broadcast_room(room, text, exclude=None):
+    with rooms_lock:
+        info = rooms.get(room)
+        if not info:
+            return
+        members = list(info.get('members', set()))
+        active_snapshot = {username: user_active_room.get(username, 'global') for username in members}
+    targets = []
+    with clients_lock:
+        for username in members:
+            if username == exclude:
+                continue
+            if active_snapshot.get(username) != room:
+                continue
+            conn = clients.get(username)
+            if conn:
+                targets.append(conn)
+    data = (text + "\n").encode('utf-8')
+    for conn in targets:
+        try:
+            conn.sendall(data)
+        except Exception:
+            pass
+
+
+def handle_join_command(username, conn, room, password):
+    room = room.strip()
+    if not room:
+        send_line(conn, "❌ Debes indicar un nombre de sala.")
+        return
+    with rooms_lock:
+        info = rooms.get(room)
+        if info:
+            stored_pwd = info.get('password')
+            if stored_pwd and username not in info['members']:
+                if password is None or password != stored_pwd:
+                    send_line(conn, "❌ Contraseña incorrecta.")
+                    return
+        else:
+            rooms[room] = {'members': set(), 'password': password if password else None}
+            info = rooms[room]
+        info['members'].add(username)
+        joined = user_joined_rooms.setdefault(username, set())
+        new_membership = room not in joined
+        joined.add(room)
+        user_active_room[username] = room
+    if new_membership:
+        broadcast_room(room, f"🔔 {username} se ha unido a la sala '{room}'.", exclude=username)
+    send_line(conn, f"✅ Te has unido a la sala '{room}'.")
+
+
+def handle_leave_command(username, conn):
+    with rooms_lock:
+        current = user_active_room.get(username, 'global')
+        if current == 'global':
+            send_line(conn, "No puedes salir del chat global.")
+            return
+        info = rooms.setdefault(current, {'members': set(), 'password': None})
+        info['members'].discard(username)
+        joined = user_joined_rooms.setdefault(username, set())
+        joined.discard(current)
+        user_active_room[username] = 'global'
+    send_line(conn, f"✅ Has salido de la sala '{current}'. Sala activa: 'global'.")
+    broadcast_room(current, f"ℹ️ {username} ha salido de la sala '{current}'.", exclude=username)
+
+
+def handle_rooms_command(conn):
+    with rooms_lock:
+        public_rooms = [(room, len(info['members'])) for room, info in rooms.items() if not info.get('password')]
+    if not public_rooms:
+        send_line(conn, "Salas públicas disponibles: (ninguna)")
+        return
+    parts = []
+    for room, count in sorted(public_rooms, key=lambda x: x[0].lower()):
+        parts.append(f"{room} (vacía)" if count == 0 else room)
+    send_line(conn, "Salas públicas disponibles: " + ', '.join(parts))
+
+
+def handle_message(username, text):
+    with rooms_lock:
+        room = user_active_room.get(username, 'global')
+    broadcast_room(room, f"{username}: {text}", exclude=username)
+
+
+def parse_command(line):
+    try:
+        return shlex.split(line)
+    except ValueError:
+        return []
+
+
+def handle_command(username, conn, line):
+    parts = parse_command(line)
+    if not parts:
+        send_line(conn, "❌ Comando inválido.")
+        return
+    cmd = parts[0].lower()
+    if cmd == '/join':
+        if len(parts) < 2:
+            send_line(conn, "Uso: /join <sala> [contraseña]")
+            return
+        room = parts[1]
+        password = parts[2] if len(parts) > 2 else None
+        handle_join_command(username, conn, room, password)
+    elif cmd == '/leave':
+        handle_leave_command(username, conn)
+    elif cmd == '/rooms':
+        handle_rooms_command(conn)
+    elif cmd == '/quitar':
+        send_line(conn, "👋 Desconectado por solicitud.")
+        raise DisconnectRequested()
+    else:
+        send_line(conn, "❌ Comando desconocido.")
+
+
+def cleanup_user(username):
+    to_notify = []
+    with rooms_lock:
+        joined = user_joined_rooms.pop(username, set())
+        user_active_room.pop(username, None)
+        for room in joined:
+            info = rooms.get(room)
+            if info and username in info['members']:
+                info['members'].discard(username)
+                to_notify.append(room)
+    with clients_lock:
+        clients.pop(username, None)
+    for room in to_notify:
+        broadcast_room(room, f"ℹ️ {username} se ha desconectado de la sala '{room}'.", exclude=username)
+
+
+def handle_client(conn, addr):
+    buffer = ''
+    username = None
+    try:
+        send_line(conn, "Ingresa tu nombre (NOMBRE):")
+        conn.settimeout(0.5)
+        while '\n' not in buffer:
+            data = conn.recv(4096)
+            if not data:
+                raise ConnectionResetError()
+            buffer += data.decode('utf-8', errors='replace')
+        line, buffer = buffer.split('\n', 1)
+        username = line.strip()
+        if not username:
+            send_line(conn, "Nombre inválido. Cerrando.")
+            return
+        with clients_lock:
+            if username in clients:
+                send_line(conn, "Nombre en uso. Intenta con otro.")
+                return
+            clients[username] = conn
+        with rooms_lock:
+            rooms.setdefault('global', {'members': set(), 'password': None})
+            rooms['global']['members'].add(username)
+            user_active_room[username] = 'global'
+            user_joined_rooms[username] = set(['global'])
+        send_line(conn, f"✅ Bienvenido {username}. Estás en 'global'.")
+        broadcast_room('global', f"ℹ️ {username} se ha unido al chat global.", exclude=username)
+
+        while True:
+            if '\n' not in buffer:
+                try:
+                    data = conn.recv(4096)
+                    if not data:
+                        raise ConnectionResetError()
+                    buffer += data.decode('utf-8', errors='replace')
+                except socket.timeout:
+                    continue
+            while '\n' in buffer:
+                line, buffer = buffer.split('\n', 1)
+                line = line.strip('\r')
+                if not line:
+                    continue
+                if line.startswith('/'):
+                    handle_command(username, conn, line)
+                else:
+                    handle_message(username, line)
+    except DisconnectRequested:
+        pass
+    except (ConnectionResetError, BrokenPipeError):
+        pass
+    finally:
+        if username:
+            cleanup_user(username)
+        try:
+            conn.close()
+        except Exception:
+            pass
+
+
+def accept_loop(server_sock):
+    print(f"[SERVER] Escuchando en {HOST}:{PORT}")
+    while True:
+        try:
+            conn, addr = server_sock.accept()
+            thread = threading.Thread(target=handle_client, args=(conn, addr), daemon=True)
+            thread.start()
+        except KeyboardInterrupt:
+            print("[SERVER] Detenido por KeyboardInterrupt.")
+            break
+        except Exception as exc:
+            print(f"[SERVER] Error en accept(): {exc}")
+            break
+
+
+def main():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        s.bind((HOST, PORT))
+        s.listen(200)
+        accept_loop(s)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- quote room names and passwords in client_v4 join commands so names with spaces work, and adjust history filenames to avoid collisions
- add server_v4 with text protocol support that parses commands with shlex so rooms and passwords containing spaces are handled safely
- remember room passwords client-side so private rooms only prompt on the first successful join and remove rooms from the sidebar after leaving
- keep users joined to rooms while they switch the active room on the server so public listings keep accurate occupancy and broadcast leave confirmations when a room is exited

## Testing
- python -m py_compile client_v4.py server_v4.py

------
https://chatgpt.com/codex/tasks/task_e_68e559518870832987cc2dbb1643e310