### PR TITLE
Implement unread message notifications in v4 client and server

### DIFF
--- a/client_v4.py
+++ b/client_v4.py
@@ -230,7 +230,7 @@ class ChatClient:
     # ----------------- Sidebar helpers -----------------
     def _format_room_display(self, room):
         count = self.unread_counts.get(room, 0)
-        return f"{room} ({count})" if count > 0 else room
+        return f"{room} ({count})"
 
     def _extract_room_from_sidebar_text(self, text):
         t = text.strip()
@@ -662,7 +662,14 @@ class ChatClient:
             self._append_local(f"[{now_ts()}] {line}", room=target_room, notify=notify)
             return
 
-        # Otros textos informativos
+        # Otros textos informativos: intentar detectar sala destino
+        inferred_room = self._parse_room_from_message(line)
+        if inferred_room:
+            self._ensure_room_entry(inferred_room)
+            notify = inferred_room != self.current_room
+            self._append_local(f"[{now_ts()}] {line}", room=inferred_room, notify=notify)
+            return
+
         self._append_local(f"[{now_ts()}] {line}", room=self.current_room)
 
     # ----------------- Envío de mensajes y comandos -----------------


### PR DESCRIPTION
## Summary
- always show unread counters next to room names in the v4 client sidebar and reuse the parsed room tag to notify inactive rooms with sound cues
- detect room tags in all incoming messages so off-room activity updates histories and unread counts
- adjust the v4 server to broadcast room-tagged messages to every member for proper unread tracking

## Testing
- python -m py_compile client_v4.py server_v4.py

------
https://chatgpt.com/codex/tasks/task_e_68e58d8ce7508329905beddb60c7061c