### PR TITLE
Add WinForms chat client project

### DIFF
--- a/client_C/ChatClient/App.config
+++ b/client_C/ChatClient/App.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
+  </startup>
+</configuration>

--- a/client_C/ChatClient/ChatClient.csproj
+++ b/client_C/ChatClient/ChatClient.csproj
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{4A0B3E5A-7CA5-4E26-9F40-19B707952EA9}</ProjectGuid>
+    <OutputType>WinExe</OutputType>
+    <RootNamespace>ChatClient</RootNamespace>
+    <AssemblyName>ChatClient</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Windows.Forms" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Web.Extensions" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="MainForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="MainForm.Designer.cs">
+      <DependentUpon>MainForm.cs</DependentUpon>
+    </Compile>
+    <Compile Include="PromptDialog.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="PromptDialog.Designer.cs">
+      <DependentUpon>PromptDialog.cs</DependentUpon>
+    </Compile>
+    <Compile Include="Utilities\HistoryManager.cs" />
+    <Compile Include="Utilities\ServerStorage.cs" />
+    <Compile Include="Utilities\Extensions.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/client_C/ChatClient/MainForm.Designer.cs
+++ b/client_C/ChatClient/MainForm.Designer.cs
@@ -1,0 +1,357 @@
+namespace ChatClient
+{
+    partial class MainForm
+    {
+        private System.ComponentModel.IContainer components = null;
+        private System.Windows.Forms.TextBox serverTextBox;
+        private System.Windows.Forms.TextBox portTextBox;
+        private System.Windows.Forms.TextBox userTextBox;
+        private System.Windows.Forms.Button connectButton;
+        private System.Windows.Forms.ComboBox serversComboBox;
+        private System.Windows.Forms.Button saveServerButton;
+        private System.Windows.Forms.ListBox roomsListBox;
+        private System.Windows.Forms.Label sidebarTitleLabel;
+        private System.Windows.Forms.Button joinedRoomsButton;
+        private System.Windows.Forms.Button publicRoomsButton;
+        private System.Windows.Forms.Button createJoinButton;
+        private System.Windows.Forms.Label activeRoomLabel;
+        private System.Windows.Forms.RichTextBox chatRichTextBox;
+        private System.Windows.Forms.TextBox messageTextBox;
+        private System.Windows.Forms.Button sendButton;
+        private System.Windows.Forms.ContextMenuStrip roomsContextMenu;
+        private System.Windows.Forms.ToolStripMenuItem leaveRoomMenuItem;
+        private System.Windows.Forms.Label labelServer;
+        private System.Windows.Forms.Label labelPort;
+        private System.Windows.Forms.Label labelUser;
+        private System.Windows.Forms.Label labelRecent;
+        private System.Windows.Forms.Panel sidebarPanel;
+        private System.Windows.Forms.Panel mainPanel;
+        private System.Windows.Forms.Panel topPanel;
+        private System.Windows.Forms.Panel bottomPanel;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        private void InitializeComponent()
+        {
+            this.components = new System.ComponentModel.Container();
+            this.serverTextBox = new System.Windows.Forms.TextBox();
+            this.portTextBox = new System.Windows.Forms.TextBox();
+            this.userTextBox = new System.Windows.Forms.TextBox();
+            this.connectButton = new System.Windows.Forms.Button();
+            this.serversComboBox = new System.Windows.Forms.ComboBox();
+            this.saveServerButton = new System.Windows.Forms.Button();
+            this.roomsListBox = new System.Windows.Forms.ListBox();
+            this.roomsContextMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.leaveRoomMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.sidebarTitleLabel = new System.Windows.Forms.Label();
+            this.joinedRoomsButton = new System.Windows.Forms.Button();
+            this.publicRoomsButton = new System.Windows.Forms.Button();
+            this.createJoinButton = new System.Windows.Forms.Button();
+            this.activeRoomLabel = new System.Windows.Forms.Label();
+            this.chatRichTextBox = new System.Windows.Forms.RichTextBox();
+            this.messageTextBox = new System.Windows.Forms.TextBox();
+            this.sendButton = new System.Windows.Forms.Button();
+            this.labelServer = new System.Windows.Forms.Label();
+            this.labelPort = new System.Windows.Forms.Label();
+            this.labelUser = new System.Windows.Forms.Label();
+            this.labelRecent = new System.Windows.Forms.Label();
+            this.sidebarPanel = new System.Windows.Forms.Panel();
+            this.mainPanel = new System.Windows.Forms.Panel();
+            this.topPanel = new System.Windows.Forms.Panel();
+            this.bottomPanel = new System.Windows.Forms.Panel();
+            this.roomsContextMenu.SuspendLayout();
+            this.sidebarPanel.SuspendLayout();
+            this.mainPanel.SuspendLayout();
+            this.topPanel.SuspendLayout();
+            this.bottomPanel.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // serverTextBox
+            // 
+            this.serverTextBox.Location = new System.Drawing.Point(69, 12);
+            this.serverTextBox.Name = "serverTextBox";
+            this.serverTextBox.Size = new System.Drawing.Size(125, 20);
+            this.serverTextBox.TabIndex = 1;
+            // 
+            // portTextBox
+            // 
+            this.portTextBox.Location = new System.Drawing.Point(236, 12);
+            this.portTextBox.Name = "portTextBox";
+            this.portTextBox.Size = new System.Drawing.Size(60, 20);
+            this.portTextBox.TabIndex = 3;
+            // 
+            // userTextBox
+            // 
+            this.userTextBox.Location = new System.Drawing.Point(348, 12);
+            this.userTextBox.Name = "userTextBox";
+            this.userTextBox.Size = new System.Drawing.Size(140, 20);
+            this.userTextBox.TabIndex = 5;
+            // 
+            // connectButton
+            // 
+            this.connectButton.Location = new System.Drawing.Point(502, 10);
+            this.connectButton.Name = "connectButton";
+            this.connectButton.Size = new System.Drawing.Size(86, 23);
+            this.connectButton.TabIndex = 6;
+            this.connectButton.Text = "Conectar";
+            this.connectButton.UseVisualStyleBackColor = true;
+            this.connectButton.Click += new System.EventHandler(this.ConnectButton_Click);
+            // 
+            // serversComboBox
+            // 
+            this.serversComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.serversComboBox.FormattingEnabled = true;
+            this.serversComboBox.Location = new System.Drawing.Point(670, 11);
+            this.serversComboBox.Name = "serversComboBox";
+            this.serversComboBox.Size = new System.Drawing.Size(160, 21);
+            this.serversComboBox.TabIndex = 9;
+            this.serversComboBox.SelectedIndexChanged += new System.EventHandler(this.ServersComboBox_SelectedIndexChanged);
+            // 
+            // saveServerButton
+            // 
+            this.saveServerButton.Location = new System.Drawing.Point(836, 10);
+            this.saveServerButton.Name = "saveServerButton";
+            this.saveServerButton.Size = new System.Drawing.Size(126, 23);
+            this.saveServerButton.TabIndex = 10;
+            this.saveServerButton.Text = "Guardar servidor...";
+            this.saveServerButton.UseVisualStyleBackColor = true;
+            this.saveServerButton.Click += new System.EventHandler(this.SaveServerButton_Click);
+            // 
+            // roomsListBox
+            // 
+            this.roomsListBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left)));
+            this.roomsListBox.ContextMenuStrip = this.roomsContextMenu;
+            this.roomsListBox.DrawMode = System.Windows.Forms.DrawMode.OwnerDrawFixed;
+            this.roomsListBox.FormattingEnabled = true;
+            this.roomsListBox.IntegralHeight = false;
+            this.roomsListBox.Location = new System.Drawing.Point(15, 44);
+            this.roomsListBox.Name = "roomsListBox";
+            this.roomsListBox.Size = new System.Drawing.Size(210, 364);
+            this.roomsListBox.TabIndex = 2;
+            this.roomsListBox.DrawItem += new System.Windows.Forms.DrawItemEventHandler(this.RoomsListBox_DrawItem);
+            this.roomsListBox.DoubleClick += new System.EventHandler(this.RoomsListBox_DoubleClick);
+            this.roomsListBox.MouseDown += new System.Windows.Forms.MouseEventHandler(this.RoomsListBox_MouseDown);
+            // 
+            // roomsContextMenu
+            // 
+            this.roomsContextMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.leaveRoomMenuItem});
+            this.roomsContextMenu.Name = "roomsContextMenu";
+            this.roomsContextMenu.Size = new System.Drawing.Size(162, 26);
+            this.roomsContextMenu.Opening += new System.ComponentModel.CancelEventHandler(this.RoomsContextMenu_Opening);
+            // 
+            // leaveRoomMenuItem
+            // 
+            this.leaveRoomMenuItem.Name = "leaveRoomMenuItem";
+            this.leaveRoomMenuItem.Size = new System.Drawing.Size(161, 22);
+            this.leaveRoomMenuItem.Text = "Salir de la sala";
+            this.leaveRoomMenuItem.Click += new System.EventHandler(this.LeaveRoomMenuItem_Click);
+            // 
+            // sidebarTitleLabel
+            // 
+            this.sidebarTitleLabel.AutoSize = true;
+            this.sidebarTitleLabel.Location = new System.Drawing.Point(12, 20);
+            this.sidebarTitleLabel.Name = "sidebarTitleLabel";
+            this.sidebarTitleLabel.Size = new System.Drawing.Size(187, 13);
+            this.sidebarTitleLabel.TabIndex = 1;
+            this.sidebarTitleLabel.Text = "Salas (doble clic para activar)";
+            // 
+            // joinedRoomsButton
+            // 
+            this.joinedRoomsButton.Location = new System.Drawing.Point(15, 418);
+            this.joinedRoomsButton.Name = "joinedRoomsButton";
+            this.joinedRoomsButton.Size = new System.Drawing.Size(102, 28);
+            this.joinedRoomsButton.TabIndex = 3;
+            this.joinedRoomsButton.Text = "Mis salas";
+            this.joinedRoomsButton.UseVisualStyleBackColor = true;
+            this.joinedRoomsButton.Click += new System.EventHandler(this.JoinedRoomsButton_Click);
+            // 
+            // publicRoomsButton
+            // 
+            this.publicRoomsButton.Location = new System.Drawing.Point(123, 418);
+            this.publicRoomsButton.Name = "publicRoomsButton";
+            this.publicRoomsButton.Size = new System.Drawing.Size(102, 28);
+            this.publicRoomsButton.TabIndex = 4;
+            this.publicRoomsButton.Text = "Listar públicas";
+            this.publicRoomsButton.UseVisualStyleBackColor = true;
+            this.publicRoomsButton.Click += new System.EventHandler(this.PublicRoomsButton_Click);
+            // 
+            // createJoinButton
+            // 
+            this.createJoinButton.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.createJoinButton.Location = new System.Drawing.Point(15, 452);
+            this.createJoinButton.Name = "createJoinButton";
+            this.createJoinButton.Size = new System.Drawing.Size(210, 30);
+            this.createJoinButton.TabIndex = 5;
+            this.createJoinButton.Text = "Crear / Unirse a sala";
+            this.createJoinButton.UseVisualStyleBackColor = true;
+            this.createJoinButton.Click += new System.EventHandler(this.CreateJoinButton_Click);
+            // 
+            // activeRoomLabel
+            // 
+            this.activeRoomLabel.AutoSize = true;
+            this.activeRoomLabel.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.activeRoomLabel.Location = new System.Drawing.Point(12, 9);
+            this.activeRoomLabel.Name = "activeRoomLabel";
+            this.activeRoomLabel.Size = new System.Drawing.Size(137, 16);
+            this.activeRoomLabel.TabIndex = 0;
+            this.activeRoomLabel.Text = "Sala activa: global";
+            // 
+            // chatRichTextBox
+            // 
+            this.chatRichTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.chatRichTextBox.Location = new System.Drawing.Point(15, 35);
+            this.chatRichTextBox.Name = "chatRichTextBox";
+            this.chatRichTextBox.ReadOnly = true;
+            this.chatRichTextBox.Size = new System.Drawing.Size(673, 409);
+            this.chatRichTextBox.TabIndex = 1;
+            this.chatRichTextBox.Text = "";
+            this.chatRichTextBox.VScroll += new System.EventHandler(this.ChatRichTextBox_VScroll);
+            // 
+            // messageTextBox
+            // 
+            this.messageTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.messageTextBox.Location = new System.Drawing.Point(15, 10);
+            this.messageTextBox.Name = "messageTextBox";
+            this.messageTextBox.Size = new System.Drawing.Size(583, 20);
+            this.messageTextBox.TabIndex = 0;
+            this.messageTextBox.KeyDown += new System.Windows.Forms.KeyEventHandler(this.MessageTextBox_KeyDown);
+            // 
+            // sendButton
+            // 
+            this.sendButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.sendButton.Enabled = false;
+            this.sendButton.Location = new System.Drawing.Point(604, 8);
+            this.sendButton.Name = "sendButton";
+            this.sendButton.Size = new System.Drawing.Size(84, 23);
+            this.sendButton.TabIndex = 1;
+            this.sendButton.Text = "Enviar";
+            this.sendButton.UseVisualStyleBackColor = true;
+            this.sendButton.Click += new System.EventHandler(this.SendButton_Click);
+            // 
+            // labelServer
+            // 
+            this.labelServer.AutoSize = true;
+            this.labelServer.Location = new System.Drawing.Point(12, 15);
+            this.labelServer.Name = "labelServer";
+            this.labelServer.Size = new System.Drawing.Size(51, 13);
+            this.labelServer.TabIndex = 0;
+            this.labelServer.Text = "Servidor:";
+            // 
+            // labelPort
+            // 
+            this.labelPort.AutoSize = true;
+            this.labelPort.Location = new System.Drawing.Point(200, 15);
+            this.labelPort.Name = "labelPort";
+            this.labelPort.Size = new System.Drawing.Size(38, 13);
+            this.labelPort.TabIndex = 2;
+            this.labelPort.Text = "Puerto:";
+            // 
+            // labelUser
+            // 
+            this.labelUser.AutoSize = true;
+            this.labelUser.Location = new System.Drawing.Point(302, 15);
+            this.labelUser.Name = "labelUser";
+            this.labelUser.Size = new System.Drawing.Size(46, 13);
+            this.labelUser.TabIndex = 4;
+            this.labelUser.Text = "Usuario:";
+            // 
+            // labelRecent
+            // 
+            this.labelRecent.AutoSize = true;
+            this.labelRecent.Location = new System.Drawing.Point(594, 15);
+            this.labelRecent.Name = "labelRecent";
+            this.labelRecent.Size = new System.Drawing.Size(52, 13);
+            this.labelRecent.TabIndex = 8;
+            this.labelRecent.Text = "Recientes:";
+            // 
+            // sidebarPanel
+            // 
+            this.sidebarPanel.Controls.Add(this.sidebarTitleLabel);
+            this.sidebarPanel.Controls.Add(this.roomsListBox);
+            this.sidebarPanel.Controls.Add(this.joinedRoomsButton);
+            this.sidebarPanel.Controls.Add(this.publicRoomsButton);
+            this.sidebarPanel.Controls.Add(this.createJoinButton);
+            this.sidebarPanel.Dock = System.Windows.Forms.DockStyle.Left;
+            this.sidebarPanel.Location = new System.Drawing.Point(0, 50);
+            this.sidebarPanel.Name = "sidebarPanel";
+            this.sidebarPanel.Size = new System.Drawing.Size(240, 500);
+            this.sidebarPanel.TabIndex = 1;
+            // 
+            // mainPanel
+            // 
+            this.mainPanel.Controls.Add(this.chatRichTextBox);
+            this.mainPanel.Controls.Add(this.activeRoomLabel);
+            this.mainPanel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.mainPanel.Location = new System.Drawing.Point(240, 50);
+            this.mainPanel.Name = "mainPanel";
+            this.mainPanel.Size = new System.Drawing.Size(703, 440);
+            this.mainPanel.TabIndex = 2;
+            // 
+            // topPanel
+            // 
+            this.topPanel.Controls.Add(this.labelServer);
+            this.topPanel.Controls.Add(this.serverTextBox);
+            this.topPanel.Controls.Add(this.labelPort);
+            this.topPanel.Controls.Add(this.portTextBox);
+            this.topPanel.Controls.Add(this.labelUser);
+            this.topPanel.Controls.Add(this.userTextBox);
+            this.topPanel.Controls.Add(this.connectButton);
+            this.topPanel.Controls.Add(this.labelRecent);
+            this.topPanel.Controls.Add(this.serversComboBox);
+            this.topPanel.Controls.Add(this.saveServerButton);
+            this.topPanel.Dock = System.Windows.Forms.DockStyle.Top;
+            this.topPanel.Location = new System.Drawing.Point(0, 0);
+            this.topPanel.Name = "topPanel";
+            this.topPanel.Size = new System.Drawing.Size(943, 50);
+            this.topPanel.TabIndex = 0;
+            // 
+            // bottomPanel
+            // 
+            this.bottomPanel.Controls.Add(this.messageTextBox);
+            this.bottomPanel.Controls.Add(this.sendButton);
+            this.bottomPanel.Dock = System.Windows.Forms.DockStyle.Bottom;
+            this.bottomPanel.Location = new System.Drawing.Point(240, 490);
+            this.bottomPanel.Name = "bottomPanel";
+            this.bottomPanel.Size = new System.Drawing.Size(703, 60);
+            this.bottomPanel.TabIndex = 3;
+            // 
+            // MainForm
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(943, 550);
+            this.Controls.Add(this.mainPanel);
+            this.Controls.Add(this.bottomPanel);
+            this.Controls.Add(this.sidebarPanel);
+            this.Controls.Add(this.topPanel);
+            this.MinimumSize = new System.Drawing.Size(960, 590);
+            this.Name = "MainForm";
+            this.Text = "Chat - Cliente (WinForms)";
+            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.MainForm_FormClosing);
+            this.roomsContextMenu.ResumeLayout(false);
+            this.sidebarPanel.ResumeLayout(false);
+            this.sidebarPanel.PerformLayout();
+            this.mainPanel.ResumeLayout(false);
+            this.mainPanel.PerformLayout();
+            this.topPanel.ResumeLayout(false);
+            this.topPanel.PerformLayout();
+            this.bottomPanel.ResumeLayout(false);
+            this.bottomPanel.PerformLayout();
+            this.ResumeLayout(false);
+
+        }
+    }
+}

--- a/client_C/ChatClient/MainForm.cs
+++ b/client_C/ChatClient/MainForm.cs
@@ -1,0 +1,949 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.IO;
+using System.Linq;
+using System.Net.Sockets;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading;
+using System.Windows.Forms;
+
+namespace ChatClient
+{
+    public partial class MainForm : Form
+    {
+        private const string DefaultHost = "127.0.0.1";
+        private const int DefaultPort = 55555;
+        private const int LoadChunk = 100;
+
+        private readonly Dictionary<string, ServerInfo> _servers;
+        private readonly HashSet<string> _visitedRooms = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<string, string> _roomPasswords = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<string, HistoryState> _historyIndex = new Dictionary<string, HistoryState>(StringComparer.OrdinalIgnoreCase);
+        private readonly List<PublicRoom> _publicRooms = new List<PublicRoom>();
+
+        private SidebarMode _sidebarMode = SidebarMode.Joined;
+        private TcpClient _client;
+        private NetworkStream _stream;
+        private Thread _listenerThread;
+        private volatile bool _running;
+        private string _username;
+        private string _serverKey = "default";
+        private string _currentRoom = "global";
+        private string _pendingJoinRoom;
+        private string _pendingJoinPassword;
+
+        private class HistoryState
+        {
+            public int StartIndex { get; set; }
+        }
+
+        private class PublicRoom
+        {
+            public PublicRoom(string name, bool isEmpty)
+            {
+                Name = name;
+                IsEmpty = isEmpty;
+            }
+
+            public string Name { get; }
+            public bool IsEmpty { get; }
+        }
+
+        private enum SidebarMode
+        {
+            Joined,
+            PublicList
+        }
+
+        private const int EmGetFirstVisibleLine = 0xCE;
+
+        [DllImport("user32.dll")]
+        private static extern int SendMessage(IntPtr hWnd, int msg, IntPtr wParam, IntPtr lParam);
+
+        public MainForm()
+        {
+            InitializeComponent();
+
+            serverTextBox.Text = DefaultHost;
+            portTextBox.Text = DefaultPort.ToString();
+            sendButton.Enabled = false;
+            chatRichTextBox.ReadOnly = true;
+
+            _servers = ServerStorage.LoadServers();
+            serversComboBox.Items.AddRange(_servers.Keys.ToArray());
+
+            _visitedRooms.Add("global");
+            RefreshSidebar();
+        }
+
+        private void ConnectButton_Click(object sender, EventArgs e)
+        {
+            if (_client != null)
+            {
+                MessageBox.Show(this, "Ya estás conectado.", "Info", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                return;
+            }
+
+            var host = serverTextBox.Text.Trim();
+            if (string.IsNullOrWhiteSpace(host))
+            {
+                MessageBox.Show(this, "Ingrese un servidor.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return;
+            }
+
+            if (!int.TryParse(portTextBox.Text.Trim(), out var port))
+            {
+                MessageBox.Show(this, "Puerto inválido.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return;
+            }
+
+            var username = userTextBox.Text.Trim();
+            if (string.IsNullOrWhiteSpace(username))
+            {
+                MessageBox.Show(this, "Ingrese un nombre de usuario.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return;
+            }
+
+            try
+            {
+                _client = new TcpClient();
+                _client.Connect(host, port);
+                _stream = _client.GetStream();
+                _stream.ReadTimeout = 2000;
+
+                var buffer = new byte[1024];
+                int bytesRead = _stream.Read(buffer, 0, buffer.Length);
+                if (bytesRead <= 0)
+                {
+                    throw new IOException("El servidor cerró la conexión durante el handshake.");
+                }
+                var prompt = Encoding.UTF8.GetString(buffer, 0, bytesRead);
+                if (!prompt.ToUpperInvariant().Contains("NOMBRE"))
+                {
+                    MessageBox.Show(this, "El servidor no envió el prompt esperado.", "Aviso", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                }
+
+                var userBytes = Encoding.UTF8.GetBytes(username + "\n");
+                _stream.Write(userBytes, 0, userBytes.Length);
+                _stream.Flush();
+                _stream.ReadTimeout = Timeout.Infinite;
+
+                _username = username;
+                _running = true;
+                _serverKey = BuildServerKey(host, port);
+                _historyIndex.Clear();
+                _roomPasswords.Clear();
+                _pendingJoinRoom = null;
+                _pendingJoinPassword = null;
+                _publicRooms.Clear();
+
+                connectButton.Enabled = false;
+                sendButton.Enabled = true;
+
+                _currentRoom = "global";
+                _visitedRooms.Clear();
+                _visitedRooms.Add("global");
+                _sidebarMode = SidebarMode.Joined;
+                activeRoomLabel.Text = "Sala activa: global";
+                LoadRoomHistoryInitial("global");
+                AppendLocal(string.Format("[{0}] Conectado a {1}:{2} como {3}", NowTs(), host, port, username), "global");
+                RefreshSidebar();
+
+                _listenerThread = new Thread(ListenLoop)
+                {
+                    IsBackground = true
+                };
+                _listenerThread.Start();
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(this, "No se pudo conectar: " + ex.Message, "Error de conexión", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                DisconnectUi();
+            }
+        }
+
+        private void ListenLoop()
+        {
+            try
+            {
+                using (var reader = new StreamReader(_stream, Encoding.UTF8, false, 1024, true))
+                {
+                    string line;
+                    while (_running && (line = reader.ReadLine()) != null)
+                    {
+                        var cleanLine = line.Trim('\r');
+                        if (!string.IsNullOrWhiteSpace(cleanLine))
+                        {
+                            BeginInvoke(new Action(() => ProcessServerLine(cleanLine)));
+                        }
+                    }
+                }
+            }
+            catch
+            {
+                // ignored - handled by finally
+            }
+            finally
+            {
+                _running = false;
+                BeginInvoke(new Action(() =>
+                {
+                    AppendLocal(string.Format("[{0}] Desconectado del servidor.", NowTs()), _currentRoom);
+                    DisconnectUi();
+                }));
+            }
+        }
+
+        private void ProcessServerLine(string line)
+        {
+            if (line.Equals("/rooms", StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            if (line.StartsWith("Salas públicas disponibles", StringComparison.OrdinalIgnoreCase))
+            {
+                _sidebarMode = SidebarMode.PublicList;
+                _publicRooms.Clear();
+                var parts = line.Split(new[] { ':' }, 2);
+                if (parts.Length == 2)
+                {
+                    var entries = parts[1].Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+                    foreach (var entry in entries)
+                    {
+                        var trimmed = entry.Trim();
+                        if (string.IsNullOrEmpty(trimmed))
+                        {
+                            continue;
+                        }
+
+                        var empty = trimmed.EndsWith("(vacía)", StringComparison.OrdinalIgnoreCase);
+                        var name = empty ? trimmed.Replace("(vacía)", string.Empty).Trim() : trimmed;
+                        _publicRooms.Add(new PublicRoom(name, empty));
+                    }
+                }
+
+                RefreshSidebar();
+                AppendLocal(string.Format("[{0}] {1}", NowTs(), line));
+                return;
+            }
+
+            if ((line.Contains("sala '") && line.IndexOf("unid", StringComparison.OrdinalIgnoreCase) >= 0) ||
+                line.IndexOf("estás ahora en la sala", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                line.IndexOf("ahora estás en la sala", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                var joinedRoom = ExtractBetween(line, "'", "'") ?? _pendingJoinRoom ?? _currentRoom;
+                if (!string.IsNullOrEmpty(joinedRoom))
+                {
+                    _currentRoom = joinedRoom;
+                    _visitedRooms.Add(joinedRoom);
+                    activeRoomLabel.Text = "Sala activa: " + joinedRoom;
+                    LoadRoomHistoryInitial(joinedRoom);
+                    _sidebarMode = SidebarMode.Joined;
+                    RefreshSidebar();
+                    if (!string.IsNullOrEmpty(_pendingJoinRoom) && string.Equals(_pendingJoinRoom, joinedRoom, StringComparison.OrdinalIgnoreCase))
+                    {
+                        if (!string.IsNullOrEmpty(_pendingJoinPassword))
+                        {
+                            _roomPasswords[joinedRoom] = _pendingJoinPassword;
+                        }
+                        _pendingJoinRoom = null;
+                        _pendingJoinPassword = null;
+                    }
+                }
+
+                AppendLocal(string.Format("[{0}] {1}", NowTs(), line), joinedRoom);
+                return;
+            }
+
+            if (line.Contains("Has salido de la sala"))
+            {
+                var leftRoom = ExtractBetween(line, "'", "'");
+                if (!string.IsNullOrEmpty(leftRoom))
+                {
+                    _visitedRooms.Remove(leftRoom);
+                    if (string.Equals(_currentRoom, leftRoom, StringComparison.OrdinalIgnoreCase))
+                    {
+                        _currentRoom = "global";
+                        _visitedRooms.Add("global");
+                        activeRoomLabel.Text = "Sala activa: global";
+                        LoadRoomHistoryInitial("global");
+                    }
+                    RefreshSidebar();
+                }
+
+                AppendLocal(string.Format("[{0}] {1}", NowTs(), line));
+                return;
+            }
+
+            if (line.Contains("❌ Contraseña incorrecta"))
+            {
+                var room = _pendingJoinRoom ?? _currentRoom;
+                if (!string.IsNullOrEmpty(room))
+                {
+                    _roomPasswords.Remove(room);
+                }
+
+                var pwd = PromptDialog.Show(this, "Contraseña requerida", "Ingrese contraseña para la sala '" + room + "':", string.Empty, true);
+                if (!string.IsNullOrEmpty(pwd))
+                {
+                    JoinRoom(room, pwd, true);
+                }
+                else
+                {
+                    AppendLocal(string.Format("[{0}] No se ingresó contraseña. No se unió a '{1}'.", NowTs(), room));
+                }
+                return;
+            }
+
+            if (line.Contains(":"))
+            {
+                AppendLocal(string.Format("[{0}] {1}", NowTs(), line));
+                return;
+            }
+
+            AppendLocal(string.Format("[{0}] {1}", NowTs(), line));
+        }
+
+        private void SendButton_Click(object sender, EventArgs e)
+        {
+            SendMessageFromInput();
+        }
+
+        private void MessageTextBox_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.KeyCode == Keys.Enter)
+            {
+                e.SuppressKeyPress = true;
+                SendMessageFromInput();
+            }
+        }
+
+        private void SendMessageFromInput()
+        {
+            if (_client == null || !_client.Connected)
+            {
+                MessageBox.Show(this, "Conéctate al servidor primero.", "No conectado", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                return;
+            }
+
+            var text = messageTextBox.Text.Trim();
+            if (string.IsNullOrEmpty(text))
+            {
+                return;
+            }
+
+            if (text.StartsWith("/"))
+            {
+                HandleCommand(text);
+            }
+            else
+            {
+                try
+                {
+                    var data = Encoding.UTF8.GetBytes(text + "\n");
+                    _stream.Write(data, 0, data.Length);
+                    _stream.Flush();
+                    AppendLocal(string.Format("[{0}] Tú: {1}", NowTs(), text));
+                }
+                catch (Exception ex)
+                {
+                    AppendLocal(string.Format("[{0}] Error al enviar: {1}", NowTs(), ex.Message));
+                    _running = false;
+                    DisconnectUi();
+                }
+            }
+
+            messageTextBox.Clear();
+        }
+
+        private void HandleCommand(string text)
+        {
+            var lower = text.ToLowerInvariant();
+            if (lower.StartsWith("/join"))
+            {
+                var parts = SplitCommand(text);
+                if (parts.Length < 2)
+                {
+                    AppendLocal("[Sistema] Uso: /join <sala> [password]");
+                }
+                else
+                {
+                    var room = parts[1];
+                    var pwd = parts.Length > 2 ? parts[2] : null;
+                    JoinRoom(room, pwd);
+                }
+            }
+            else if (lower.StartsWith("/leave"))
+            {
+                SendRaw(text);
+            }
+            else if (lower.StartsWith("/rooms"))
+            {
+                RequestRooms();
+            }
+            else if (lower.StartsWith("/quitar"))
+            {
+                Close();
+            }
+            else
+            {
+                AppendLocal("[Sistema] Comando desconocido.");
+            }
+        }
+
+        private void JoinRoom(string room, string password = null, bool silent = false)
+        {
+            if (string.IsNullOrWhiteSpace(room))
+            {
+                return;
+            }
+
+            _pendingJoinRoom = room;
+            _pendingJoinPassword = string.IsNullOrEmpty(password) && _roomPasswords.ContainsKey(room)
+                ? _roomPasswords[room]
+                : password;
+
+            if (!silent)
+            {
+                AppendLocal(string.Format("[{0}] Intentando unirse a '{1}'...", NowTs(), room));
+            }
+
+            var cmd = FormatJoinCommand(room, _pendingJoinPassword);
+            SendRaw(cmd);
+        }
+
+        private void RequestRooms()
+        {
+            _sidebarMode = SidebarMode.PublicList;
+            _publicRooms.Clear();
+            RefreshSidebar();
+            SendRaw("/rooms");
+        }
+
+        private void SendRaw(string command)
+        {
+            if (_client == null || !_client.Connected)
+            {
+                return;
+            }
+
+            try
+            {
+                var data = Encoding.UTF8.GetBytes(command + "\n");
+                _stream.Write(data, 0, data.Length);
+                _stream.Flush();
+            }
+            catch (Exception ex)
+            {
+                AppendLocal(string.Format("[{0}] Error al enviar comando: {1}", NowTs(), ex.Message));
+            }
+        }
+
+        private static string[] SplitCommand(string text)
+        {
+            var parts = new List<string>();
+            var current = new StringBuilder();
+            bool inQuotes = false;
+            for (int i = 0; i < text.Length; i++)
+            {
+                var c = text[i];
+                if (c == '"')
+                {
+                    inQuotes = !inQuotes;
+                    continue;
+                }
+
+                if (!inQuotes && char.IsWhiteSpace(c))
+                {
+                    if (current.Length > 0)
+                    {
+                        parts.Add(current.ToString());
+                        current.Clear();
+                    }
+                }
+                else
+                {
+                    current.Append(c);
+                }
+            }
+
+            if (current.Length > 0)
+            {
+                parts.Add(current.ToString());
+            }
+
+            return parts.ToArray();
+        }
+
+        private void LoadRoomHistoryInitial(string room)
+        {
+            var path = HistoryManager.HistoryPath(room, _serverKey);
+            var tuple = HistoryManager.TailLines(path, LoadChunk);
+            var lines = tuple.Item1;
+            var startIdx = tuple.Item2;
+            _historyIndex[room] = new HistoryState { StartIndex = startIdx };
+
+            chatRichTextBox.SuspendLayout();
+            chatRichTextBox.Clear();
+            foreach (var line in lines)
+            {
+                chatRichTextBox.AppendText(line);
+            }
+            if (lines.Count > 0 && !lines.Last().EndsWith("\n"))
+            {
+                chatRichTextBox.AppendText(Environment.NewLine);
+            }
+            chatRichTextBox.SelectionStart = chatRichTextBox.TextLength;
+            chatRichTextBox.ScrollToCaret();
+            chatRichTextBox.ResumeLayout();
+        }
+
+        private void LoadMoreHistoryChunk()
+        {
+            if (!_historyIndex.TryGetValue(_currentRoom, out var state))
+            {
+                return;
+            }
+
+            if (state.StartIndex == 0)
+            {
+                return;
+            }
+
+            var path = HistoryManager.HistoryPath(_currentRoom, _serverKey);
+            var tuple = HistoryManager.HeadChunk(path, state.StartIndex, LoadChunk);
+            var lines = tuple.Item1;
+            var newStart = tuple.Item2;
+            if (lines.Count == 0)
+            {
+                return;
+            }
+
+            var currentSelection = chatRichTextBox.SelectionStart;
+            chatRichTextBox.SuspendLayout();
+            chatRichTextBox.Text = string.Join(string.Empty, lines) + chatRichTextBox.Text;
+            var index = chatRichTextBox.GetFirstCharIndexFromLine(lines.Count);
+            if (index < 0)
+            {
+                index = 0;
+            }
+            chatRichTextBox.SelectionStart = index;
+            chatRichTextBox.ScrollToCaret();
+            chatRichTextBox.ResumeLayout();
+            state.StartIndex = newStart;
+        }
+
+        private void AppendLocal(string text, string room = null)
+        {
+            var targetRoom = room ?? _currentRoom;
+            HistoryManager.AppendHistoryLine(targetRoom, text, _serverKey);
+            if (string.Equals(targetRoom, _currentRoom, StringComparison.OrdinalIgnoreCase))
+            {
+                chatRichTextBox.AppendText(text + Environment.NewLine);
+                chatRichTextBox.SelectionStart = chatRichTextBox.TextLength;
+                chatRichTextBox.ScrollToCaret();
+            }
+        }
+
+        private void RefreshSidebar()
+        {
+            roomsListBox.BeginUpdate();
+            roomsListBox.Items.Clear();
+
+            if (_sidebarMode == SidebarMode.Joined)
+            {
+                sidebarTitleLabel.Text = "Salas (doble clic para activar)";
+                var items = new List<string>();
+                if (_visitedRooms.Contains("global"))
+                {
+                    items.Add("global");
+                }
+                items.AddRange(_visitedRooms.Where(r => !string.Equals(r, "global", StringComparison.OrdinalIgnoreCase)).OrderBy(r => r, StringComparer.OrdinalIgnoreCase));
+                foreach (var room in items)
+                {
+                    var prefix = string.Equals(room, _currentRoom, StringComparison.OrdinalIgnoreCase) ? "• " : "  ";
+                    roomsListBox.Items.Add(prefix + room);
+                }
+            }
+            else
+            {
+                sidebarTitleLabel.Text = "Salas públicas (doble clic para unirse)";
+                if (_publicRooms.Count == 0)
+                {
+                    roomsListBox.Items.Add("(no hay salas públicas)");
+                }
+                else
+                {
+                    foreach (var room in _publicRooms.OrderBy(r => r.Name, StringComparer.OrdinalIgnoreCase))
+                    {
+                        roomsListBox.Items.Add(room.IsEmpty ? room.Name + " (vacía)" : room.Name);
+                    }
+                }
+            }
+
+            roomsListBox.EndUpdate();
+        }
+
+        private void RoomsListBox_DrawItem(object sender, DrawItemEventArgs e)
+        {
+            e.DrawBackground();
+            if (e.Index < 0 || e.Index >= roomsListBox.Items.Count)
+            {
+                return;
+            }
+
+            var text = roomsListBox.Items[e.Index].ToString();
+            var isSelected = (e.State & DrawItemState.Selected) == DrawItemState.Selected;
+            var color = isSelected ? SystemColors.HighlightText : SystemColors.ControlText;
+            if (_sidebarMode == SidebarMode.PublicList && text.EndsWith("(vacía)", StringComparison.OrdinalIgnoreCase) && !isSelected)
+            {
+                color = Color.Gray;
+            }
+
+            using (var brush = new SolidBrush(color))
+            {
+                e.Graphics.DrawString(text, e.Font, brush, e.Bounds);
+            }
+            e.DrawFocusRectangle();
+        }
+
+        private void RoomsListBox_DoubleClick(object sender, EventArgs e)
+        {
+            if (roomsListBox.SelectedItem == null)
+            {
+                return;
+            }
+
+            var text = roomsListBox.SelectedItem.ToString().Trim();
+            if (_sidebarMode == SidebarMode.Joined)
+            {
+                var room = text.StartsWith("• ") || text.StartsWith("  ") ? text.Substring(2).Trim() : text;
+                if (!string.Equals(room, _currentRoom, StringComparison.OrdinalIgnoreCase))
+                {
+                    JoinRoom(room);
+                }
+            }
+            else
+            {
+                if (text == "(no hay salas públicas)")
+                {
+                    return;
+                }
+                var room = text.Replace("(vacía)", string.Empty).Trim();
+                JoinRoom(room);
+            }
+        }
+
+        private void RoomsListBox_MouseDown(object sender, MouseEventArgs e)
+        {
+            if (e.Button == MouseButtons.Right)
+            {
+                var index = roomsListBox.IndexFromPoint(e.Location);
+                if (index >= 0)
+                {
+                    roomsListBox.SelectedIndex = index;
+                }
+            }
+        }
+
+        private void RoomsContextMenu_Opening(object sender, System.ComponentModel.CancelEventArgs e)
+        {
+            if (_sidebarMode != SidebarMode.Joined || roomsListBox.SelectedItem == null)
+            {
+                e.Cancel = true;
+            }
+        }
+
+        private void LeaveRoomMenuItem_Click(object sender, EventArgs e)
+        {
+            if (_sidebarMode != SidebarMode.Joined)
+            {
+                return;
+            }
+
+            if (roomsListBox.SelectedItem == null)
+            {
+                return;
+            }
+
+            var text = roomsListBox.SelectedItem.ToString().Trim();
+            var room = text.StartsWith("• ") || text.StartsWith("  ") ? text.Substring(2).Trim() : text;
+            if (string.Equals(room, "global", StringComparison.OrdinalIgnoreCase))
+            {
+                MessageBox.Show(this, "No podés salir de la sala global.", "Info", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                return;
+            }
+
+            if (string.Equals(room, _currentRoom, StringComparison.OrdinalIgnoreCase))
+            {
+                SendRaw("/leave");
+            }
+            else
+            {
+                SendRaw(FormatLeaveCommand(room));
+            }
+        }
+
+        private void JoinedRoomsButton_Click(object sender, EventArgs e)
+        {
+            _sidebarMode = SidebarMode.Joined;
+            RefreshSidebar();
+        }
+
+        private void PublicRoomsButton_Click(object sender, EventArgs e)
+        {
+            RequestRooms();
+        }
+
+        private void CreateJoinButton_Click(object sender, EventArgs e)
+        {
+            using (var dialog = new CreateJoinRoomDialog())
+            {
+                if (dialog.ShowDialog(this) == DialogResult.OK)
+                {
+                    JoinRoom(dialog.RoomName, string.IsNullOrEmpty(dialog.Password) ? null : dialog.Password);
+                }
+            }
+        }
+
+        private void ChatRichTextBox_VScroll(object sender, EventArgs e)
+        {
+            var line = SendMessage(chatRichTextBox.Handle, EmGetFirstVisibleLine, IntPtr.Zero, IntPtr.Zero);
+            if (line <= 0)
+            {
+                LoadMoreHistoryChunk();
+            }
+        }
+
+        private void ServersComboBox_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            var name = serversComboBox.SelectedItem as string;
+            if (name != null && _servers.TryGetValue(name, out var info))
+            {
+                serverTextBox.Text = info.Host ?? DefaultHost;
+                portTextBox.Text = info.Port.ToString();
+            }
+        }
+
+        private void SaveServerButton_Click(object sender, EventArgs e)
+        {
+            var alias = PromptDialog.Show(this, "Guardar servidor", "Alias para este servidor:");
+            if (string.IsNullOrWhiteSpace(alias))
+            {
+                return;
+            }
+
+            if (!int.TryParse(portTextBox.Text.Trim(), out var port))
+            {
+                MessageBox.Show(this, "Puerto inválido.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                return;
+            }
+
+            var host = serverTextBox.Text.Trim();
+            _servers[alias] = new ServerInfo { Host = host, Port = port };
+            ServerStorage.SaveServers(_servers);
+            serversComboBox.Items.Clear();
+            serversComboBox.Items.AddRange(_servers.Keys.ToArray());
+            serversComboBox.SelectedItem = alias;
+            MessageBox.Show(this, "Servidor guardado como '" + alias + "'", "Guardado", MessageBoxButtons.OK, MessageBoxIcon.Information);
+        }
+
+        private void DisconnectUi()
+        {
+            _running = false;
+            sendButton.Enabled = false;
+            connectButton.Enabled = true;
+            if (_stream != null)
+            {
+                try
+                {
+                    _stream.Dispose();
+                }
+                catch
+                {
+                    // ignore
+                }
+                _stream = null;
+            }
+
+            if (_client != null)
+            {
+                try
+                {
+                    _client.Close();
+                }
+                catch
+                {
+                    // ignore
+                }
+                _client = null;
+            }
+            _listenerThread = null;
+        }
+
+        private void MainForm_FormClosing(object sender, FormClosingEventArgs e)
+        {
+            _running = false;
+            try
+            {
+                _stream?.Close();
+            }
+            catch
+            {
+                // ignore
+            }
+            try
+            {
+                _client?.Close();
+            }
+            catch
+            {
+                // ignore
+            }
+        }
+
+        private static string FormatJoinCommand(string room, string password)
+        {
+            if (string.IsNullOrEmpty(password))
+            {
+                return "/join " + QuoteIfNeeded(room);
+            }
+
+            return "/join " + QuoteIfNeeded(room) + " " + QuoteIfNeeded(password);
+        }
+
+        private static string FormatLeaveCommand(string room)
+        {
+            return "/leave " + QuoteIfNeeded(room);
+        }
+
+        private static string QuoteIfNeeded(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return "";
+            }
+
+            if (value.IndexOf(' ') >= 0)
+            {
+                return '"' + value.Replace("\"", "\\\"") + '"';
+            }
+
+            return value;
+        }
+
+        private static string BuildServerKey(string host, int port)
+        {
+            return host + ":" + port;
+        }
+
+        private static string NowTs()
+        {
+            return DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss");
+        }
+
+        private static string ExtractBetween(string input, string start, string end)
+        {
+            var startIdx = input.IndexOf(start, StringComparison.Ordinal);
+            if (startIdx < 0)
+            {
+                return null;
+            }
+
+            startIdx += start.Length;
+            var endIdx = input.IndexOf(end, startIdx, StringComparison.Ordinal);
+            if (endIdx < 0)
+            {
+                return null;
+            }
+
+            return input.Substring(startIdx, endIdx - startIdx);
+        }
+
+        private sealed class CreateJoinRoomDialog : Form
+        {
+            private readonly TextBox _nameTextBox;
+            private readonly TextBox _passwordTextBox;
+            private readonly Button _okButton;
+
+            public string RoomName => _nameTextBox.Text.Trim();
+            public string Password => _passwordTextBox.Text.Trim();
+
+            public CreateJoinRoomDialog()
+            {
+                Text = "Crear / Unirse a sala";
+                FormBorderStyle = FormBorderStyle.FixedDialog;
+                MaximizeBox = false;
+                MinimizeBox = false;
+                StartPosition = FormStartPosition.CenterParent;
+                ClientSize = new Size(320, 150);
+
+                var nameLabel = new Label
+                {
+                    Text = "Nombre de la sala:",
+                    Location = new Point(12, 15),
+                    AutoSize = true
+                };
+                Controls.Add(nameLabel);
+
+                _nameTextBox = new TextBox
+                {
+                    Location = new Point(150, 12),
+                    Width = 150
+                };
+                Controls.Add(_nameTextBox);
+
+                var pwdLabel = new Label
+                {
+                    Text = "Contraseña (opcional):",
+                    Location = new Point(12, 55),
+                    AutoSize = true
+                };
+                Controls.Add(pwdLabel);
+
+                _passwordTextBox = new TextBox
+                {
+                    Location = new Point(150, 52),
+                    Width = 150,
+                    UseSystemPasswordChar = true
+                };
+                Controls.Add(_passwordTextBox);
+
+                _okButton = new Button
+                {
+                    Text = "Aceptar",
+                    DialogResult = DialogResult.OK,
+                    Location = new Point(110, 100),
+                    Size = new Size(90, 27)
+                };
+                _okButton.Click += OkButton_Click;
+                Controls.Add(_okButton);
+
+                var cancelButton = new Button
+                {
+                    Text = "Cancelar",
+                    DialogResult = DialogResult.Cancel,
+                    Location = new Point(210, 100),
+                    Size = new Size(90, 27)
+                };
+                Controls.Add(cancelButton);
+
+                AcceptButton = _okButton;
+                CancelButton = cancelButton;
+            }
+
+            private void OkButton_Click(object sender, EventArgs e)
+            {
+                if (string.IsNullOrWhiteSpace(RoomName))
+                {
+                    MessageBox.Show(this, "Debes escribir un nombre para la sala.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    DialogResult = DialogResult.None;
+                    return;
+                }
+            }
+        }
+    }
+}

--- a/client_C/ChatClient/Program.cs
+++ b/client_C/ChatClient/Program.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Windows.Forms;
+
+namespace ChatClient
+{
+    internal static class Program
+    {
+        [STAThread]
+        private static void Main()
+        {
+            Application.EnableVisualStyles();
+            Application.SetCompatibleTextRenderingDefault(false);
+            HistoryManager.EnsureHistoryDirectory();
+            Application.Run(new MainForm());
+        }
+    }
+}

--- a/client_C/ChatClient/PromptDialog.Designer.cs
+++ b/client_C/ChatClient/PromptDialog.Designer.cs
@@ -1,0 +1,88 @@
+namespace ChatClient
+{
+    partial class PromptDialog
+    {
+        private System.ComponentModel.IContainer components = null;
+        private System.Windows.Forms.Label messageLabel;
+        private System.Windows.Forms.TextBox inputTextBox;
+        private System.Windows.Forms.Button okButton;
+        private System.Windows.Forms.Button cancelButton;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        private void InitializeComponent()
+        {
+            this.messageLabel = new System.Windows.Forms.Label();
+            this.inputTextBox = new System.Windows.Forms.TextBox();
+            this.okButton = new System.Windows.Forms.Button();
+            this.cancelButton = new System.Windows.Forms.Button();
+            this.SuspendLayout();
+            // 
+            // messageLabel
+            // 
+            this.messageLabel.AutoSize = true;
+            this.messageLabel.Location = new System.Drawing.Point(12, 15);
+            this.messageLabel.Name = "messageLabel";
+            this.messageLabel.Size = new System.Drawing.Size(63, 13);
+            this.messageLabel.TabIndex = 0;
+            this.messageLabel.Text = "Placeholder";
+            // 
+            // inputTextBox
+            // 
+            this.inputTextBox.Location = new System.Drawing.Point(15, 40);
+            this.inputTextBox.Name = "inputTextBox";
+            this.inputTextBox.Size = new System.Drawing.Size(318, 20);
+            this.inputTextBox.TabIndex = 1;
+            // 
+            // okButton
+            // 
+            this.okButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.okButton.Location = new System.Drawing.Point(177, 78);
+            this.okButton.Name = "okButton";
+            this.okButton.Size = new System.Drawing.Size(75, 23);
+            this.okButton.TabIndex = 2;
+            this.okButton.Text = "Aceptar";
+            this.okButton.UseVisualStyleBackColor = true;
+            this.okButton.Click += new System.EventHandler(this.OkButton_Click);
+            // 
+            // cancelButton
+            // 
+            this.cancelButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.cancelButton.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.cancelButton.Location = new System.Drawing.Point(258, 78);
+            this.cancelButton.Name = "cancelButton";
+            this.cancelButton.Size = new System.Drawing.Size(75, 23);
+            this.cancelButton.TabIndex = 3;
+            this.cancelButton.Text = "Cancelar";
+            this.cancelButton.UseVisualStyleBackColor = true;
+            // 
+            // PromptDialog
+            // 
+            this.AcceptButton = this.okButton;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.CancelButton = this.cancelButton;
+            this.ClientSize = new System.Drawing.Size(345, 113);
+            this.Controls.Add(this.cancelButton);
+            this.Controls.Add(this.okButton);
+            this.Controls.Add(this.inputTextBox);
+            this.Controls.Add(this.messageLabel);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.Name = "PromptDialog";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "Entrada";
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+    }
+}

--- a/client_C/ChatClient/PromptDialog.cs
+++ b/client_C/ChatClient/PromptDialog.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Windows.Forms;
+
+namespace ChatClient
+{
+    public partial class PromptDialog : Form
+    {
+        private PromptDialog(string title, string message, string defaultValue, bool mask)
+        {
+            InitializeComponent();
+            Text = title;
+            messageLabel.Text = message;
+            inputTextBox.Text = defaultValue ?? string.Empty;
+            if (mask)
+            {
+                inputTextBox.UseSystemPasswordChar = true;
+            }
+        }
+
+        private void OkButton_Click(object sender, EventArgs e)
+        {
+            DialogResult = DialogResult.OK;
+            Close();
+        }
+
+        public static string Show(IWin32Window owner, string title, string message, string defaultValue = "", bool mask = false)
+        {
+            using (var dialog = new PromptDialog(title, message, defaultValue, mask))
+            {
+                return dialog.ShowDialog(owner) == DialogResult.OK ? dialog.inputTextBox.Text : null;
+            }
+        }
+    }
+}

--- a/client_C/ChatClient/Utilities/Extensions.cs
+++ b/client_C/ChatClient/Utilities/Extensions.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Windows.Forms;
+
+namespace ChatClient
+{
+    internal static class Extensions
+    {
+        public static void SafeInvoke(this Control control, Action action)
+        {
+            if (control.InvokeRequired)
+            {
+                control.BeginInvoke(action);
+            }
+            else
+            {
+                action();
+            }
+        }
+    }
+}

--- a/client_C/ChatClient/Utilities/HistoryManager.cs
+++ b/client_C/ChatClient/Utilities/HistoryManager.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace ChatClient
+{
+    internal static class HistoryManager
+    {
+        public const string HistoryDirectory = "chat_history";
+
+        public static void EnsureHistoryDirectory(string path = null)
+        {
+            var target = string.IsNullOrWhiteSpace(path) ? HistoryDirectory : path;
+            if (!Directory.Exists(target))
+            {
+                Directory.CreateDirectory(target);
+            }
+        }
+
+        private static string Sanitize(string name, string fallback)
+        {
+            if (string.IsNullOrEmpty(name))
+            {
+                return fallback;
+            }
+
+            var builder = new StringBuilder();
+            foreach (var ch in name)
+            {
+                if (char.IsLetterOrDigit(ch) || ch == '_' || ch == '-' || ch == '.' || ch == '@')
+                {
+                    builder.Append(ch);
+                }
+                else if (char.IsWhiteSpace(ch))
+                {
+                    builder.Append('_');
+                }
+                else
+                {
+                    builder.Append('_');
+                }
+            }
+
+            var sanitized = builder.ToString().Trim('_');
+            return string.IsNullOrEmpty(sanitized) ? fallback : sanitized;
+        }
+
+        public static string HistoryPath(string room, string serverKey = "default")
+        {
+            EnsureHistoryDirectory();
+            var safeServer = Sanitize(serverKey, "default");
+            var serverDir = Path.Combine(HistoryDirectory, safeServer);
+            EnsureHistoryDirectory(serverDir);
+            var safeRoom = Sanitize(room, "room");
+            return Path.Combine(serverDir, safeRoom + ".txt");
+        }
+
+        public static Tuple<List<string>, int> TailLines(string filepath, int n)
+        {
+            if (!File.Exists(filepath))
+            {
+                return Tuple.Create(new List<string>(), 0);
+            }
+
+            var rawLines = File.ReadAllLines(filepath, Encoding.UTF8).ToList();
+            var total = rawLines.Count;
+            var start = Math.Max(0, total - n);
+            var result = rawLines.Skip(start).Select(l => l + Environment.NewLine).ToList();
+            return Tuple.Create(result, start);
+        }
+
+        public static Tuple<List<string>, int> HeadChunk(string filepath, int startIndex, int chunk)
+        {
+            if (!File.Exists(filepath))
+            {
+                return Tuple.Create(new List<string>(), 0);
+            }
+
+            var rawLines = File.ReadAllLines(filepath, Encoding.UTF8).ToList();
+            var newStart = Math.Max(0, startIndex - chunk);
+            var result = rawLines.Skip(newStart).Take(startIndex - newStart).Select(l => l + Environment.NewLine).ToList();
+            return Tuple.Create(result, newStart);
+        }
+
+        public static void AppendHistoryLine(string room, string line, string serverKey)
+        {
+            var path = HistoryPath(room, serverKey);
+            EnsureHistoryDirectory(Path.GetDirectoryName(path));
+            using (var writer = new StreamWriter(path, true, Encoding.UTF8))
+            {
+                if (!line.EndsWith("\n"))
+                {
+                    writer.WriteLine(line);
+                }
+                else
+                {
+                    writer.Write(line);
+                }
+            }
+        }
+    }
+}

--- a/client_C/ChatClient/Utilities/ServerStorage.cs
+++ b/client_C/ChatClient/Utilities/ServerStorage.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Web.Script.Serialization;
+
+namespace ChatClient
+{
+    internal static class ServerStorage
+    {
+        public const string ServerFile = "servers.json";
+        private static readonly JavaScriptSerializer Serializer = new JavaScriptSerializer();
+
+        public static Dictionary<string, ServerInfo> LoadServers()
+        {
+            try
+            {
+                if (!File.Exists(ServerFile))
+                {
+                    return new Dictionary<string, ServerInfo>();
+                }
+
+                var json = File.ReadAllText(ServerFile, Encoding.UTF8);
+                if (string.IsNullOrWhiteSpace(json))
+                {
+                    return new Dictionary<string, ServerInfo>();
+                }
+
+                var raw = Serializer.Deserialize<Dictionary<string, ServerInfo>>(json);
+                return raw ?? new Dictionary<string, ServerInfo>();
+            }
+            catch
+            {
+                return new Dictionary<string, ServerInfo>();
+            }
+        }
+
+        public static void SaveServers(Dictionary<string, ServerInfo> servers)
+        {
+            try
+            {
+                var json = Serializer.Serialize(servers ?? new Dictionary<string, ServerInfo>());
+                File.WriteAllText(ServerFile, json, Encoding.UTF8);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("Error guardando servers.json: " + ex.Message);
+            }
+        }
+    }
+
+    internal class ServerInfo
+    {
+        public string Host { get; set; }
+        public int Port { get; set; }
+    }
+}

--- a/client_C/client_C.sln
+++ b/client_C/client_C.sln
@@ -1,0 +1,21 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.168
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ChatClient", "ChatClient\ChatClient.csproj", "{4A0B3E5A-7CA5-4E26-9F40-19B707952EA9}"
+EndProject
+Global
+    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+        Debug|Any CPU = Debug|Any CPU
+        Release|Any CPU = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(ProjectConfigurationPlatforms) = postSolution
+        {4A0B3E5A-7CA5-4E26-9F40-19B707952EA9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {4A0B3E5A-7CA5-4E26-9F40-19B707952EA9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {4A0B3E5A-7CA5-4E26-9F40-19B707952EA9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {4A0B3E5A-7CA5-4E26-9F40-19B707952EA9}.Release|Any CPU.Build.0 = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(SolutionProperties) = preSolution
+        HideSolutionNode = FALSE
+    EndGlobalSection
+EndGlobal


### PR DESCRIPTION
## Summary
- port the Python Tkinter client to a Windows Forms application targeting .NET Framework 4.7.2
- add supporting utilities for persistent chat history and saved server management
- include a Visual Studio solution and project configuration for the new client

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e6a96b6adc8329b7c0321ef0774236